### PR TITLE
Call URI.open directly

### DIFF
--- a/lib/jekyll-get-json/converter.rb
+++ b/lib/jekyll-get-json/converter.rb
@@ -22,7 +22,7 @@ module JekyllGetJson
       config.each do |d|
         begin
           target = site.data[d['data']]
-          source = JSON.load(open(d['json']))
+          source = JSON.load(URI.open(d['json']))
 
           if target
             target.deep_merge(source)


### PR DESCRIPTION
Makes it work in Ruby 3.0.

Close https://github.com/brockfanning/jekyll-get-json/issues/4